### PR TITLE
修正一个错误的返回类型

### DIFF
--- a/MCMODDLL/Minecraft.hpp
+++ b/MCMODDLL/Minecraft.hpp
@@ -1,6 +1,6 @@
 /*
-¸ÃÎÄ¼ş´æ·ÅMinecraftÄÚ²¿ÄæÏò·ÖÎöµÃµ½µÄÊı¾İ½á¹¹£¬ÓÉÓÚÓÃÍ¾ÏŞÖÆ£¬ÕâÀïµÄ½á¹¹¿ÉÄÜ²»ÍêÕû¡£
-Èç¹ûÎ´À´°æ±¾£¨¸ßÓÚ1.11.4.2°æ±¾£©¸üĞÂµ¼ÖÂÊı¾İ½á¹¹±ä»¯£¬ÇëÄú×ÔĞĞ·ÖÎöÔÙĞŞÕı¡£
+è¯¥æ–‡ä»¶å­˜æ”¾Minecraftå†…éƒ¨é€†å‘åˆ†æå¾—åˆ°çš„æ•°æ®ç»“æ„ï¼Œç”±äºç”¨é€”é™åˆ¶ï¼Œè¿™é‡Œçš„ç»“æ„å¯èƒ½ä¸å®Œæ•´ã€‚
+å¦‚æœæœªæ¥ç‰ˆæœ¬ï¼ˆé«˜äº1.11.4.2ç‰ˆæœ¬ï¼‰æ›´æ–°å¯¼è‡´æ•°æ®ç»“æ„å˜åŒ–ï¼Œè¯·æ‚¨è‡ªè¡Œåˆ†æå†ä¿®æ­£ã€‚
 */
 #pragma once
 
@@ -17,12 +17,12 @@ struct SharedPtr {
 };
 
 struct BlockLegacy {
-	// »ñÈ¡·½¿éÃû
+	// è·å–æ–¹å—å
 	auto getFullName() const {
 		return (std::string&) * (__int64*)((__int64)this + 104);
 	}
 
-	// »ñÈ¡·½¿éIDºÅ
+	// è·å–æ–¹å—IDå·
 	auto getBlockItemID() const {
 		return SYM_CALL(short (*)(const BlockLegacy*),
 			MSSYM_B1QE14getBlockItemIdB1AE11BlockLegacyB2AAA7QEBAFXZ,
@@ -32,14 +32,14 @@ struct BlockLegacy {
 };
 
 struct BlockPos {
-	// »ñÈ¡×ø±êÊı×éÍ·
+	// è·å–åæ ‡æ•°ç»„å¤´
 	INT32* getPosition() const {
 		return reinterpret_cast<INT32*>(reinterpret_cast<VA>(this));
 	}
 };
 
 struct Block {
-	// »ñÈ¡Ô´
+	// è·å–æº
 	const BlockLegacy* getLegacyBlock() const {
 		return SYM_CALL(const BlockLegacy * (*)(const Block*),
 			MSSYM_B1QE14getLegacyBlockB1AA5BlockB2AAE19QEBAAEBVBlockLegacyB2AAA2XZ,
@@ -48,18 +48,18 @@ struct Block {
 };
 
 struct BlockActor {
-	// È¡·½¿é
+	// å–æ–¹å—
 	Block* getBlock() {
 		return *reinterpret_cast<Block**>(reinterpret_cast<VA>(this) + 16);
 	}
-	// È¡·½¿éÎ»ÖÃ
+	// å–æ–¹å—ä½ç½®
 	BlockPos* getPosition() {
 		return reinterpret_cast<BlockPos*>(reinterpret_cast<VA>(this) + 44);
 	}
 };
 
 struct BlockSource {
-	// È¡·½¿é
+	// å–æ–¹å—
 	const Block* getBlock(const BlockPos* blkpos) {
 		return SYM_CALL(const Block * (*)(decltype(this), decltype(blkpos)),
 			MSSYM_B1QA8getBlockB1AE11BlockSourceB2AAE13QEBAAEBVBlockB2AAE12AEBVBlockPosB3AAAA1Z,
@@ -74,25 +74,25 @@ struct Vec3 {
 };
 
 struct Actor {
-	// È¡·½¿éÔ´
+	// å–æ–¹å—æº
 	BlockSource* getRegion() {
 		return *reinterpret_cast<BlockSource**>(reinterpret_cast<VA>(this) + 414*sizeof(void*));
 	}
-	// È¡Î¬¶ÈID
+	// å–ç»´åº¦ID
 	int getDimension() {
 		return *reinterpret_cast<int*>(reinterpret_cast<VA>(this) + 188);
 	}
-	// È¡Ãû×Ö±êÇ©
+	// å–åå­—æ ‡ç­¾
 	const std::string* getNameTag() const {
 		return SYM_CALL(const std::string * (*)(const Actor*),
 			MSSYM_B1QE10getNameTagB1AA5ActorB2AAA8UEBAAEBVB2QDA5basicB1UA6stringB1AA2DUB2QDA4charB1UA6traitsB1AA1DB1AA3stdB2AAA1VB2QDA9allocatorB1AA1DB1AA12B2AAA3stdB2AAA2XZ,
 			this);
 	}
-	// ÊÇ·ñĞü¿Õ
+	// æ˜¯å¦æ‚¬ç©º
 	const byte isStand() {
 		return *reinterpret_cast<byte *>(reinterpret_cast<VA>(this) + 376);
 	}
-	// È¡Íæ¼ÒÎ»ÖÃ
+	// å–ç©å®¶ä½ç½®
 	Vec3* getPos() {
 		return (Vec3*)SYM_CALL(Vec3 *(*)(void *),
 			MSSYM_B1QA6getPosB1AA5ActorB2AAE12UEBAAEBVVec3B2AAA2XZ,
@@ -111,7 +111,7 @@ struct GameMode {
 };
 
 struct ContainerManagerModel {
-	// È¡¿ªÈİÕß
+	// å–å¼€å®¹è€…
 	Player* getPlayer() {
 		return *reinterpret_cast<Player**>(reinterpret_cast<VA>(this) + 8);
 	}
@@ -121,19 +121,19 @@ struct LevelContainerManagerModel
 };
 
 struct ItemStack {
-	// È¡ÎïÆ·ID
+	// å–ç‰©å“ID
 	int getId() {
 		return SYM_CALL(int(*)(ItemStack*),
 			MSSYM_B1QA5getIdB1AE13ItemStackBaseB2AAA7QEBAFXZ,
 			this);
 	}
-	// È¡ÎïÆ·Ãû³Æ
-	INT64 getName(std::string& str) {
-		return SYM_CALL(INT64(*)(decltype(this), decltype(str)),
+	// å–ç‰©å“åç§°
+	std::string getName() {
+		return SYM_CALL(std::string(*)(ItemStack*),
 			MSSYM_B1QA7getNameB1AE13ItemStackBaseB2AAA4QEBAB1QA2AVB2QDA5basicB1UA6stringB1AA2DUB2QDA4charB1UA6traitsB1AA1DB1AA3stdB2AAA1VB2QDA9allocatorB1AA1DB1AA12B2AAA3stdB2AAA2XZ,
-			this, str);
+			this;
 	}
-	// È¡ÈİÆ÷ÄÚÊıÁ¿
+	// å–å®¹å™¨å†…æ•°é‡
 	int getStackSize() {
 		return SYM_CALL(int(*)(ItemStack*),
 			MSSYM_B1QA8getCountB1AE18ContainerItemStackB2AAA7QEBAHXZ,

--- a/MCMODDLL/mod.cpp
+++ b/MCMODDLL/mod.cpp
@@ -4,24 +4,24 @@
 #include "Minecraft.hpp"
 using namespace SymHook;
 
-/**¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª**
- |              MOD C++ÎÄ¼ş               |
- **¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª**
-ËµÃ÷£º
-¸ÃcppÎÄ¼şµÄÄ¿µÄÊÇ°üº¬MOD¹¦ÄÜÖ÷Òª´úÂë£¬Çë½«Ö÷Òª²¿·Ö´úÂëĞ´ÔÚÕâ¸öÎÄ¼şÄÚ£¡
-¡°T¡±¿ªÍ·µÄÏµÁĞHookºêÔÚÄ£¿é¼ÓÔØµÄÊ±ºòµ÷ÓÃ£¬Ê¹ÓÃ·½·¨Çë²Î¿¼MCMrARMµÄmodloader¡£
-µØÖ·£ºhttps://github.com/minecraft-linux/server-modloader/wiki
-Çë×¢Òâ£ºÊ¹ÓÃ·½·¨ÂÔÓĞ²»Í¬£¬±¾ÎÄ¼şµÄº¯Êı·ûºÅÓÃµÄÊÇPDB¹¤¾ßÉú³ÉµÄC++±äÁ¿£¬¶ø²»ÊÇ×Ö·û´®×ÖÃæÁ¿£¡
-ÁíÍâ£¬¸ÃÎÄ¼ş°üº¬Á½¸öº¯Êımod_initºÍmod_exit£¬·Ö±ğÔÚ¸ÃÄ£¿é¼ÓÔØ»òÍË³öÊ±µ÷ÓÃ¡£
-±¾Ä£¿éÀı×Ó£º
-THook(void,							// º¯Êı·µ»ØÀàĞÍ
-	MSSYM_XXXXXXXXXXXXXXXXXXXXX,	// º¯Êı·ûºÅÃû¶ÔÓ¦µÄC++±äÁ¿£¨Î»ÓÚSymHook.h£©
-	__int64 a1, __int64 a2) {		// º¯Êı²ÎÊıÀàĞÍÁĞ±í£¨¼ÙÉè´æÔÚ²ÎÊıa1Óëa2£©
+/**â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”**
+ |              MOD C++æ–‡ä»¶               |
+ **â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”**
+è¯´æ˜ï¼š
+è¯¥cppæ–‡ä»¶çš„ç›®çš„æ˜¯åŒ…å«MODåŠŸèƒ½ä¸»è¦ä»£ç ï¼Œè¯·å°†ä¸»è¦éƒ¨åˆ†ä»£ç å†™åœ¨è¿™ä¸ªæ–‡ä»¶å†…ï¼
+â€œTâ€å¼€å¤´çš„ç³»åˆ—Hookå®åœ¨æ¨¡å—åŠ è½½çš„æ—¶å€™è°ƒç”¨ï¼Œä½¿ç”¨æ–¹æ³•è¯·å‚è€ƒMCMrARMçš„modloaderã€‚
+åœ°å€ï¼šhttps://github.com/minecraft-linux/server-modloader/wiki
+è¯·æ³¨æ„ï¼šä½¿ç”¨æ–¹æ³•ç•¥æœ‰ä¸åŒï¼Œæœ¬æ–‡ä»¶çš„å‡½æ•°ç¬¦å·ç”¨çš„æ˜¯PDBå·¥å…·ç”Ÿæˆçš„C++å˜é‡ï¼Œè€Œä¸æ˜¯å­—ç¬¦ä¸²å­—é¢é‡ï¼
+å¦å¤–ï¼Œè¯¥æ–‡ä»¶åŒ…å«ä¸¤ä¸ªå‡½æ•°mod_initå’Œmod_exitï¼Œåˆ†åˆ«åœ¨è¯¥æ¨¡å—åŠ è½½æˆ–é€€å‡ºæ—¶è°ƒç”¨ã€‚
+æœ¬æ¨¡å—ä¾‹å­ï¼š
+THook(void,							// å‡½æ•°è¿”å›ç±»å‹
+	MSSYM_XXXXXXXXXXXXXXXXXXXXX,	// å‡½æ•°ç¬¦å·åå¯¹åº”çš„C++å˜é‡ï¼ˆä½äºSymHook.hï¼‰
+	__int64 a1, __int64 a2) {		// å‡½æ•°å‚æ•°ç±»å‹åˆ—è¡¨ï¼ˆå‡è®¾å­˜åœ¨å‚æ•°a1ä¸a2ï¼‰
 	std::cout << "Hello world!" << std::endl;
-	original(a1, a2);				// µ÷ÓÃ¸Ãº¯ÊıHookÇ°µÄÔ­Ê¼º¯Êı
+	original(a1, a2);				// è°ƒç”¨è¯¥å‡½æ•°Hookå‰çš„åŸå§‹å‡½æ•°
 }
 */
-// ´Ë´¦¿ªÊ¼±àĞ´MOD´úÂë
+// æ­¤å¤„å¼€å§‹ç¼–å†™MODä»£ç 
 
 #include <map>
 #include <unordered_map>
@@ -30,7 +30,7 @@ THook(void,							// º¯Êı·µ»ØÀàĞÍ
 
 //std::map<short, std::string> BlockRegMap;
 
-// ×¢²á·½¿éµÄÊ±ºò¹¹½¨·½¿éID²éÕÒ±í
+// æ³¨å†Œæ–¹å—çš„æ—¶å€™æ„å»ºæ–¹å—IDæŸ¥æ‰¾è¡¨
 //THook(void,
 //	MSSYM_B1QE14registerBlocksB1AE17VanillaBlockTypesB2AAA5YAXXZ,
 //	void* _this) {
@@ -98,11 +98,11 @@ namespace Log {
 
 		auto Dimension(int v) {
 			switch (v) {
-			case 0: return u8"Ö÷ÊÀ½ç";
-			case 1: return u8"µØÓü";
-			case 2: return u8"Ä©µØ";
+			case 0: return u8"ä¸»ä¸–ç•Œ";
+			case 1: return u8"åœ°ç‹±";
+			case 2: return u8"æœ«åœ°";
 			}
-			return u8"Î´ÖªÎ¬¶È";
+			return u8"æœªçŸ¥ç»´åº¦";
 		}
 	}
 
@@ -112,63 +112,63 @@ namespace Log {
 		void Error(const std::string& title, const std::string& player_name, int dimension, const std::string& content) {
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò" << " " << player_name << " "
-				<< u8"ÔÚ" << Dimension(dimension)
+				<< u8"ç©å®¶" << " " << player_name << " "
+				<< u8"åœ¨" << Dimension(dimension)
 				<< content << std::endl;
 		}
 		void Block(const std::string& title, const std::string& player_name, char isStand, int dimension, const std::string& operation, const std::string & block_name, INT32 coordinator[]) {
 			auto block_name_inner = block_name;
 			if (block_name_inner == "")
-				block_name_inner = u8"Î´ÖªÀàĞÍ";
+				block_name_inner = u8"æœªçŸ¥ç±»å‹";
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò" << " " << player_name << " " << (!isStand ? u8"Ğü¿ÕµØ " : "")
-				<< u8"ÔÚ" <<Dimension(dimension)<< " " << Coordinator(coordinator) << " "
+				<< u8"ç©å®¶" << " " << player_name << " " << (!isStand ? u8"æ‚¬ç©ºåœ° " : "")
+				<< u8"åœ¨" <<Dimension(dimension)<< " " << Coordinator(coordinator) << " "
 				<< operation << " "
-				<< block_name_inner << " " << u8"·½¿é¡£"
+				<< block_name_inner << " " << u8"æ–¹å—ã€‚"
 				<< std::endl;
 		}
 		void Item(const std::string& title, const std::string& player_name, char isStand, int dimension, const std::string& operation, const std::string& item_name, INT32 coordinator[]) {
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò" << " " << player_name << " " << (!isStand ? u8"Ğü¿ÕµØ " : "")
-				<< u8"ÔÚ" << Dimension(dimension) << " " << Coordinator(coordinator) << " "
+				<< u8"ç©å®¶" << " " << player_name << " " << (!isStand ? u8"æ‚¬ç©ºåœ° " : "")
+				<< u8"åœ¨" << Dimension(dimension) << " " << Coordinator(coordinator) << " "
 				<< operation << " "
-				<< item_name << " " << u8"ÎïÆ·¡£"
+				<< item_name << " " << u8"ç‰©å“ã€‚"
 				<< std::endl;
 		}
 		void Interaction(const std::string& title, const std::string& player_name, char isStand, int dimension, const std::string& operation, const std::string& object_name, INT32 coordinator[]) {
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò" << " " << player_name << " " << (!isStand ? u8"Ğü¿ÕµØ " : "")
+				<< u8"ç©å®¶" << " " << player_name << " " << (!isStand ? u8"æ‚¬ç©ºåœ° " : "")
 				<< operation 
-				<< u8"ÔÚ" << Dimension(dimension) << " " << Coordinator(coordinator) << " " << u8"µÄ"
-				<< object_name << u8"¡£"
+				<< u8"åœ¨" << Dimension(dimension) << " " << Coordinator(coordinator) << " " << u8"çš„"
+				<< object_name << u8"ã€‚"
 				<< std::endl;
 		}
 		void Container_In(const std::string& title, const std::string& player_name, int dimension, int slot, int count, const std::string& object_name) {
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò" << " " << player_name << " "
-				<< u8"ÔÚ" << " " << slot << " " << u8"²ÛÄÚ"
-				<< u8"·ÅÈë" << " "
-				<< count << " " << u8"¸ö" << " "
-				<< object_name << " " << u8"ÎïÆ·¡£"
+				<< u8"ç©å®¶" << " " << player_name << " "
+				<< u8"åœ¨" << " " << slot << " " << u8"æ§½å†…"
+				<< u8"æ”¾å…¥" << " "
+				<< count << " " << u8"ä¸ª" << " "
+				<< object_name << " " << u8"ç‰©å“ã€‚"
 				<< std::endl;
 		}
 		void Container_Out(const std::string& title, const std::string& player_name, int dimension, int slot) {
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò" << " " << player_name << " "
-				<< u8"È¡³ö" << " " << slot << " " << u8"²ÛÄÚÎïÆ·¡£"
+				<< u8"ç©å®¶" << " " << player_name << " "
+				<< u8"å–å‡º" << " " << slot << " " << u8"æ§½å†…ç‰©å“ã€‚"
 				<< std::endl;
 		}
 
 		void ChangeDimension(const std::string& title, const std::string& player_name, int dimension, Vec3 *v) {
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò " << player_name << u8" ¸Ä±äÎ¬¶ÈÖÁ "
-				<< Dimension(dimension) << " " << Pos(v) + u8"¡£"
+				<< u8"ç©å®¶ " << player_name << u8" æ”¹å˜ç»´åº¦è‡³ "
+				<< Dimension(dimension) << " " << Pos(v) + u8"ã€‚"
 				<< std::endl;
 		}
 
@@ -176,8 +176,8 @@ namespace Log {
 			const std::string& msg, const std::string& chat_style) {
 			std::cout
 				<< Title(title) << " "
-				<< u8"Íæ¼Ò " << player_name << (target != "" ? u8" ÇÄÇÄµØ¶Ô " + target : "")
-				<< u8" Ëµ:" << msg
+				<< u8"ç©å®¶ " << player_name << (target != "" ? u8" æ‚„æ‚„åœ°å¯¹ " + target : "")
+				<< u8" è¯´:" << msg
 				<< std::endl;
 		}
 
@@ -188,32 +188,31 @@ namespace Log {
 		void showDie(const std::string& title, const std::string& mob_name, const std::string& src_name) {
 			std::cout
 				<< Title(title) << " "
-				<< mob_name << u8" ±» " << ((src_name != "") ? src_name : " ") << u8" É±ËÀÁË" << std::endl;
+				<< mob_name << u8" è¢« " << ((src_name != "") ? src_name : " ") << u8" æ€æ­»äº†" << std::endl;
 		}
 	}
 };
 
-// Íæ¼Ò·ÅÖÃ·½¿é
+// ç©å®¶æ”¾ç½®æ–¹å—
 THook(__int64,
 	MSSYM_B1QE21onBlockPlacedByPlayerB1AE34VanillaServerGameplayEventListenerB2AAA4UEAAB1QE14AW4EventResultB2AAE10AEAVPlayerB2AAA9AEBVBlockB2AAE12AEBVBlockPosB3AAUA1NB1AA1Z,
 	void* _this, Player* pPlayer, const Block* pBlk, const BlockPos* pBlkpos, bool _bool) {
-	Log::Player::Block("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"·ÅÖÃ", pBlk->getLegacyBlock()->getFullName(), pBlkpos->getPosition());
+	Log::Player::Block("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"æ”¾ç½®", pBlk->getLegacyBlock()->getFullName(), pBlkpos->getPosition());
 	return original(_this, pPlayer, pBlk, pBlkpos, _bool);
 }
-// Íæ¼Ò²Ù×÷ÎïÆ·
+// ç©å®¶æ“ä½œç‰©å“
 THook(bool,
 	MSSYM_B1QA9useItemOnB1AA8GameModeB2AAA4UEAAB1UE14NAEAVItemStackB2AAE12AEBVBlockPosB2AAA9EAEBVVec3B2AAA9PEBVBlockB3AAAA1Z,
 	void* _this, ItemStack* item, const BlockPos* pBlkpos, unsigned __int8 a4, void *v5, Block* pBlk) {
 	auto pPlayer = *reinterpret_cast<Player * *>(reinterpret_cast<VA>(_this) + 8);
-	std::string mstr = "";
-	item->getName(mstr);
+	std::string mstr = item->getName();
 	bool ret = original(_this, item, pBlkpos, a4, v5, pBlk);
 	if (ret) {
-		Log::Player::Item("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"²Ù×÷", mstr, pBlkpos->getPosition());
+		Log::Player::Item("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"æ“ä½œ", mstr, pBlkpos->getPosition());
 	}
 	return ret;
 }
-// Íæ¼ÒÆÆ»µ·½¿é
+// ç©å®¶ç ´åæ–¹å—
 THook(bool,
 	MSSYM_B2QUE20destroyBlockInternalB1AA8GameModeB2AAA4AEAAB1UE13NAEBVBlockPosB2AAA1EB1AA1Z,
 	void * _this, const BlockPos* pBlkpos) {
@@ -224,48 +223,48 @@ THook(bool,
 	bool ret = original(_this, pBlkpos);
 	if (!ret)
 		return ret;
-	Log::Player::Block("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"ÆÆ»µ", block_name, pBlkpos->getPosition());
+	Log::Player::Block("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"ç ´å", block_name, pBlkpos->getPosition());
 	return ret;
 }
 
-// Íæ¼Ò´ò¿ªÏä×Ó
+// ç©å®¶æ‰“å¼€ç®±å­
 THook(void,
 	MSSYM_B1QA9startOpenB1AE15ChestBlockActorB2AAE15UEAAXAEAVPlayerB3AAAA1Z,
 	void* _this, Player* pPlayer) {
 	auto real_this = reinterpret_cast<void*>(reinterpret_cast<VA>(_this) - 248);
 	auto pBlkpos = reinterpret_cast<BlockActor*>(real_this)->getPosition();
-	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"¿ªÆô", u8"Ïä×Ó", pBlkpos->getPosition());
+	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"å¼€å¯", u8"ç®±å­", pBlkpos->getPosition());
 	original(_this, pPlayer);
 }
-// Íæ¼Ò´ò¿ªÄ¾Í°
+// ç©å®¶æ‰“å¼€æœ¨æ¡¶
 THook(void,
 	MSSYM_B1QA9startOpenB1AE16BarrelBlockActorB2AAE15UEAAXAEAVPlayerB3AAAA1Z,
 	void* _this, Player* pPlayer) {
 	auto real_this = reinterpret_cast<void*>(reinterpret_cast<VA>(_this) - 248);
 	auto pBlkpos = reinterpret_cast<BlockActor*>(real_this)->getPosition();
-	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"¿ªÆô", u8"Ä¾Í°", pBlkpos->getPosition());
+	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"å¼€å¯", u8"æœ¨æ¡¶", pBlkpos->getPosition());
 	original(_this, pPlayer);
 }
-// Íæ¼Ò¹Ø±ÕÏä×Ó
+// ç©å®¶å…³é—­ç®±å­
 THook(__int64,
 	MSSYM_B1QA8stopOpenB1AE15ChestBlockActorB2AAE15UEAAXAEAVPlayerB3AAAA1Z,
 	void* _this, Player * pPlayer) {
 	auto real_this = reinterpret_cast<void*>(reinterpret_cast<VA>(_this) - 248);
 	auto pBlkpos = reinterpret_cast<BlockActor*>(real_this)->getPosition();
-	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"¹Ø±Õ", u8"Ïä×Ó", pBlkpos->getPosition());
+	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"å…³é—­", u8"ç®±å­", pBlkpos->getPosition());
 	return original(_this, pPlayer);
 }
-// Íæ¼Ò¹Ø±ÕÄ¾Í°
+// ç©å®¶å…³é—­æœ¨æ¡¶
 THook(__int64,
 	MSSYM_B1QA8stopOpenB1AE16BarrelBlockActorB2AAE15UEAAXAEAVPlayerB3AAAA1Z,
 	void* _this, Player* pPlayer) {
 	auto real_this = reinterpret_cast<void*>(reinterpret_cast<VA>(_this) - 248);
 	auto pBlkpos = reinterpret_cast<BlockActor*>(real_this)->getPosition();
-	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"¹Ø±Õ", u8"Ä¾Í°", pBlkpos->getPosition());
+	Log::Player::Interaction("Event", pPlayer->getNameTag()->c_str(), pPlayer->isStand(), pPlayer->getDimension(), u8"å…³é—­", u8"æœ¨æ¡¶", pBlkpos->getPosition());
 	return original(_this, pPlayer);
 }
 
-// Íæ¼Ò·ÅÈëÈ¡³öÊıÁ¿
+// ç©å®¶æ”¾å…¥å–å‡ºæ•°é‡
 THook(void,
 	MSSYM_B1QA7setSlotB1AE26LevelContainerManagerModelB2AAE28UEAAXHAEBUContainerItemStackB3AAUA1NB1AA1Z,
 	LevelContainerManagerModel * _this, int a2, ContainerItemStack * a3) {
@@ -275,18 +274,17 @@ THook(void,
 	auto size = pItemStack->getStackSize();
 	auto pPlayer = _this->getPlayer();
 	if (id >= 0) {
-		std::string object_name;
-		pItemStack->getName(object_name);
+		std::string object_name = pItemStack->getName();
 		if (size == 0) {
 			Log::Player::Container_Out("Event", pPlayer->getNameTag()->c_str(), pPlayer->getDimension(), slot);
 		} else
 			Log::Player::Container_In("Event", pPlayer->getNameTag()->c_str(), pPlayer->getDimension(), slot, size, object_name);
 	} else
-		Log::Player::Error("Warning", pPlayer->getNameTag()->c_str(), pPlayer->getDimension(), u8"Ê¹ÓÃÁËÎ´Öª·½¿é£¡");
+		Log::Player::Error("Warning", pPlayer->getNameTag()->c_str(), pPlayer->getDimension(), u8"ä½¿ç”¨äº†æœªçŸ¥æ–¹å—ï¼");
 	original(_this, a2, a3);
 }
 
-// Íæ¼ÒÇĞ»»Î¬¶È
+// ç©å®¶åˆ‡æ¢ç»´åº¦
 THook(bool,
 	MSSYM_B2QUE21playerChangeDimensionB1AA5LevelB2AAA4AEAAB1UE11NPEAVPlayerB2AAE26AEAVChangeDimensionRequestB3AAAA1Z,
 	void* _this, Player* pPlayer, void* req) {
@@ -296,7 +294,7 @@ THook(bool,
 	return ret;
 }
 
-// ÃüÃûÉúÎïËÀÍö
+// å‘½åç”Ÿç‰©æ­»äº¡
 THook(void,
 	MSSYM_B1QA3dieB1AA3MobB2AAE26UEAAXAEBVActorDamageSourceB3AAAA1Z,
 	Mob* _this, void* dmsg) {
@@ -322,7 +320,7 @@ THook(void,
 	original(_this, dmsg);
 }
 
-// ÁÄÌìÏûÏ¢
+// èŠå¤©æ¶ˆæ¯
 THook(void,
 	MSSYM_MD5_ad251f2fd8c27eb22c0c01209e8df83c,
 	void * _this, std::string& player_name, std::string& target, std::string& msg, std::string& char_style) {
@@ -333,12 +331,12 @@ THook(void,
 
 
 
-// ÏÂÃæÁ½¸öº¯Êı²»ÊÇ±ØÒªµÄ£¬Äã¿ÉÒÔÊ¹ÓÃ£¬Ò²¿ÉÒÔ²»Ê¹ÓÃ¡£
+// ä¸‹é¢ä¸¤ä¸ªå‡½æ•°ä¸æ˜¯å¿…è¦çš„ï¼Œä½ å¯ä»¥ä½¿ç”¨ï¼Œä¹Ÿå¯ä»¥ä¸ä½¿ç”¨ã€‚
 void mod_init() {
-	// ´Ë´¦ÌîĞ´Ä£¿é¼ÓÔØÊ±ºòµÄ²Ù×÷
+	// æ­¤å¤„å¡«å†™æ¨¡å—åŠ è½½æ—¶å€™çš„æ“ä½œ
 	// system("chcp 65001");
-	std::cout << u8"{¼à¿Ø²å¼şÒÑ¼ÓÔØ¡£" << std::endl;
+	std::cout << u8"{ç›‘æ§æ’ä»¶å·²åŠ è½½ã€‚" << std::endl;
 }
 void mod_exit() {
-	// ´Ë´¦ÌîĞ´Ä£¿éĞ¶ÔØÊ±ºòµÄ²Ù×÷
+	// æ­¤å¤„å¡«å†™æ¨¡å—å¸è½½æ—¶å€™çš„æ“ä½œ
 }


### PR DESCRIPTION
```
?getName@ItemStackBase@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ
```
的原型应为
```
public: class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl ItemStackBase::getName(void)const __ptr64
```
在针对的EZ魔改版中导致无法获取物品名
（已见在symbol.h中修改，但头文件中错误）
附上魔改版源码和调试文件
[BehaviorLog.zip](https://github.com/zhkj-liuxiaohua/MCMODDLL-CPP/files/4354305/BehaviorLog.zip)
